### PR TITLE
Tweak react-native-drawer to support react-native 0.70

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# CI owners
+/.semaphore/   @Countingup/security-approvers
+
+# Restrict changes to CODEOWNERS file itself
+/.github/CODEOWNERS   @Countingup/security-approvers
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,0 @@
-# CI owners
-/.semaphore/   @Countingup/security-approvers
-
-# Restrict changes to CODEOWNERS file itself
-/.github/CODEOWNERS   @Countingup/security-approvers
-

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-navigation-drawer",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Drawer navigator component for React Navigation",
   "main": "lib/commonjs/index.js",
   "react-native": "lib/module/index.js",

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { Dimensions, StyleSheet, ViewStyle } from 'react-native';
+import {
+  Dimensions,
+  EmitterSubscription,
+  StyleSheet,
+  ViewStyle,
+} from 'react-native';
 import {
   SceneView,
   ThemeColors,
@@ -92,7 +97,10 @@ export default class DrawerView extends React.PureComponent<Props, State> {
       this.handleDrawerOpen();
     }
 
-    Dimensions.addEventListener('change', this.updateWidth);
+    this.changeListener = (Dimensions.addEventListener(
+      'change',
+      this.updateWidth
+    ) as unknown) as EmitterSubscription;
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -109,8 +117,10 @@ export default class DrawerView extends React.PureComponent<Props, State> {
   }
 
   componentWillUnmount() {
-    Dimensions.removeEventListener('change', this.updateWidth);
+    this.changeListener?.remove();
   }
+
+  changeListener: EmitterSubscription | undefined = undefined;
 
   context!: React.ContextType<typeof ThemeContext>;
 


### PR DESCRIPTION
Dimensions.removeEventListener has been removed & addEventListener now returns the listener with a `remove` method -- updating to handle this.